### PR TITLE
Added a trigger listener for the git-package-release-update-pl

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,3 +495,4 @@ You can but not recommended non-version control your pipelines by running the fo
 oc apply --recursive --filename pipelines/{pick expiermental, incubator or stable}
 ```
 
+

--- a/pipelines/stable/git-package-release-update/bindings/trigger-listener.yaml
+++ b/pipelines/stable/git-package-release-update/bindings/trigger-listener.yaml
@@ -1,0 +1,18 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: pipeline-manager
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - name: pipeline-manager-trig
+      bindings:
+        - ref: git-package-release-update-pl-push-binding
+      template:
+        name: git-package-release-update-pl-template
+      interceptors:
+        - cel:
+            filter: "header.match('X-GitHub-Event', 'push') && body.ref == 'refs/heads/master'"
+            overlays:
+              - key: extensions.truncated_sha
+                expression: "body.head_commit.id.truncate(7)"


### PR DESCRIPTION
This pull request filters out github events and only generates a pipeline-run when pushing to the master branch of the `devops-pipelines` repository.